### PR TITLE
Adding rgb escape sequences parsing

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -76,8 +76,24 @@ impl EscapeSequence {
                     14 => ColorType::Bright(Color::Cyan),
                     15 => ColorType::Bright(Color::White),
 
-                    // TODO: Implemente rgb colors https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
-                    16..=255 => ColorType::Rgb((0, 0, 0)),
+                    // 6x6x6 color cube: indices 16–231
+                    16..=231 => {
+                        let idx = **n - 16;
+
+                        let r = idx / 36;
+                        let g = (idx / 6) % 6;
+                        let b = idx % 6;
+
+                        // Each step maps to: 0-0, 1-95, 2-135, 3-175, 4-215, 5-255
+                        let to_byte = |v: u16| if v == 0 { 0u8 } else { (55 + v * 40) as u8 };
+                        ColorType::Rgb((to_byte(r), to_byte(g), to_byte(b)))
+                    }
+
+                    // Grayscale ramp: indices 232–255 (8, 18, 28, ... 238)
+                    232..=255 => {
+                        let level = ((**n - 232) * 10 + 8) as u8;
+                        ColorType::Rgb((level, level, level))
+                    }
 
                     _ => return vec![Self::Unimplemented(vec![**fg_or_bg, 5, **n])],
                 };
@@ -90,6 +106,16 @@ impl EscapeSequence {
                     48 => vec![Self::BackgroundColor(color)],
 
                     _ => vec![Self::Unimplemented(vec![**fg_or_bg, 5, **n])],
+                }
+            }
+
+            // 24 bits, truecolor
+            [fg_or_bg, 2, r, g, b] if **r <= 255 && **g <= 255 && **b <= 255 => {
+                let color = ColorType::Rgb((**r as u8, **g as u8, **b as u8));
+                match fg_or_bg {
+                    38 => vec![Self::ForegroundColor(color)],
+                    48 => vec![Self::BackgroundColor(color)],
+                    _ => vec![Self::Unimplemented(vec![**fg_or_bg, 2, **r, **g, **b])],
                 }
             }
 

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -183,14 +183,14 @@ impl EscapeSequence {
 
             75 => Self::NeitherSuperscriptNorSubscript,
 
-            90 => Self::BackgroundColor(ColorType::Bright(Color::Black)),
-            91 => Self::BackgroundColor(ColorType::Bright(Color::Red)),
-            92 => Self::BackgroundColor(ColorType::Bright(Color::Green)),
-            93 => Self::BackgroundColor(ColorType::Bright(Color::Yellow)),
-            94 => Self::BackgroundColor(ColorType::Bright(Color::Blue)),
-            95 => Self::BackgroundColor(ColorType::Bright(Color::Magenta)),
-            96 => Self::BackgroundColor(ColorType::Bright(Color::Cyan)),
-            97 => Self::BackgroundColor(ColorType::Bright(Color::White)),
+            90 => Self::ForegroundColor(ColorType::Bright(Color::Black)),
+            91 => Self::ForegroundColor(ColorType::Bright(Color::Red)),
+            92 => Self::ForegroundColor(ColorType::Bright(Color::Green)),
+            93 => Self::ForegroundColor(ColorType::Bright(Color::Yellow)),
+            94 => Self::ForegroundColor(ColorType::Bright(Color::Blue)),
+            95 => Self::ForegroundColor(ColorType::Bright(Color::Magenta)),
+            96 => Self::ForegroundColor(ColorType::Bright(Color::Cyan)),
+            97 => Self::ForegroundColor(ColorType::Bright(Color::White)),
 
             100 => Self::BackgroundColor(ColorType::Bright(Color::Black)),
             101 => Self::BackgroundColor(ColorType::Bright(Color::Red)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,12 @@ use vte::Parser;
 mod color;
 mod escape;
 mod opt;
-mod pallete;
+mod palette;
 mod printer;
 
 use crate::{
     opt::Opt,
-    pallete::Palette,
+    palette::Palette,
     printer::Settings,
 };
 
@@ -48,7 +48,7 @@ fn main() {
         y: font_height,
     };
 
-    let pallete = Palette::Custom;
+    let palette = Palette::Custom;
     let png_width = opt.png_width;
 
     let mut statemachine = Parser::new();
@@ -59,7 +59,7 @@ fn main() {
         font_italic_bold,
         font_height,
         scale,
-        pallete,
+        palette,
         png_width,
     });
 

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -37,59 +37,59 @@ pub struct PaletteData {
 }
 
 impl Palette {
-    fn pallete(&self) -> PaletteData {
+    fn palette(&self) -> PaletteData {
         match self {
-            Palette::Custom => pallete_custom(),
-            Palette::Test => pallete_test(),
+            Palette::Custom => palette_custom(),
+            Palette::Test => palette_test(),
         }
     }
 
     pub fn get_color(&self, color: ColorType) -> [u8; 3] {
-        let pallete = self.pallete();
+        let palette = self.palette();
 
         match color {
-            ColorType::PrimaryForeground => pallete.primary_foreground,
-            ColorType::PrimaryBackground => pallete.primary_background,
+            ColorType::PrimaryForeground => palette.primary_foreground,
+            ColorType::PrimaryBackground => palette.primary_background,
             ColorType::Rgb(rgb) => [rgb.0, rgb.1, rgb.2],
 
             ColorType::Normal(color) => match color {
-                Color::Black => pallete.black,
-                Color::Red => pallete.red,
-                Color::Green => pallete.green,
-                Color::Yellow => pallete.yellow,
-                Color::Blue => pallete.blue,
-                Color::Magenta => pallete.magenta,
-                Color::Cyan => pallete.cyan,
-                Color::White => pallete.white,
+                Color::Black => palette.black,
+                Color::Red => palette.red,
+                Color::Green => palette.green,
+                Color::Yellow => palette.yellow,
+                Color::Blue => palette.blue,
+                Color::Magenta => palette.magenta,
+                Color::Cyan => palette.cyan,
+                Color::White => palette.white,
             },
 
             ColorType::Bright(color) => match color {
-                Color::Black => pallete.bright_black,
-                Color::Red => pallete.bright_red,
-                Color::Green => pallete.bright_green,
-                Color::Yellow => pallete.bright_yellow,
-                Color::Blue => pallete.bright_blue,
-                Color::Magenta => pallete.bright_magenta,
-                Color::Cyan => pallete.bright_cyan,
-                Color::White => pallete.bright_white,
+                Color::Black => palette.bright_black,
+                Color::Red => palette.bright_red,
+                Color::Green => palette.bright_green,
+                Color::Yellow => palette.bright_yellow,
+                Color::Blue => palette.bright_blue,
+                Color::Magenta => palette.bright_magenta,
+                Color::Cyan => palette.bright_cyan,
+                Color::White => palette.bright_white,
             },
         }
     }
 
     pub fn get_faint_color(&self, color: ColorType) -> [u8; 3] {
         let color = self.get_color(color);
-        let background = self.pallete().primary_background;
+        let background = self.palette().primary_background;
 
         // Blending with background
         [
             ((color[0] as u16 + background[0] as u16) / 2) as u8,
             ((color[1] as u16 + background[1] as u16) / 2) as u8,
-            ((color[2] as u16 + background[2] as u16) / 2) as u8
+            ((color[2] as u16 + background[2] as u16) / 2) as u8,
         ]
     }
 }
 
-fn pallete_custom() -> PaletteData {
+fn palette_custom() -> PaletteData {
     PaletteData {
         // primary_background: "0x161616".parse().unwrap()
         // primary_foreground: "0xf2f2f2".parse().unwrap()
@@ -116,7 +116,7 @@ fn pallete_custom() -> PaletteData {
     }
 }
 
-fn pallete_test() -> PaletteData {
+fn palette_test() -> PaletteData {
     PaletteData {
         // primary_background: "0x161616".parse().unwrap()
         // primary_foreground: "0xf2f2f2".parse().unwrap()

--- a/src/pallete.rs
+++ b/src/pallete.rs
@@ -75,6 +75,18 @@ impl Palette {
             },
         }
     }
+
+    pub fn get_faint_color(&self, color: ColorType) -> [u8; 3] {
+        let color = self.get_color(color);
+        let background = self.pallete().primary_background;
+
+        // Blending with background
+        [
+            ((color[0] as u16 + background[0] as u16) / 2) as u8,
+            ((color[1] as u16 + background[1] as u16) / 2) as u8,
+            ((color[2] as u16 + background[2] as u16) / 2) as u8
+        ]
+    }
 }
 
 fn pallete_custom() -> PaletteData {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -44,6 +44,7 @@ struct TextEntry {
     background_color: ColorType,
     font: FontState,
     underline: bool,
+    faint: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -64,6 +65,7 @@ struct State {
     font: FontState,
     last_execute_byte: Option<u8>,
     underline: bool,
+    faint: bool
 }
 
 pub(super) struct Printer<'a> {
@@ -108,6 +110,7 @@ impl Default for State {
             font: FontState::Normal,
             last_execute_byte: None,
             underline: false,
+            faint: false,
         }
     }
 }
@@ -122,6 +125,7 @@ impl Perform for Printer<'_> {
                 background_color: self.state.background_color,
                 font: self.state.font,
                 underline: self.state.underline,
+                faint: self.state.faint,
             },
         );
 
@@ -187,6 +191,7 @@ impl Perform for Printer<'_> {
                     self.state.background_color = defaults.background_color;
                     self.state.font = defaults.font;
                     self.state.underline = false;
+                    self.state.faint = false;
                 }
 
                 EscapeSequence::Bold => self.state.font += FontState::Bold,
@@ -212,8 +217,15 @@ impl Perform for Printer<'_> {
                     self.state.background_color = ColorType::PrimaryBackground
                 }
 
+                EscapeSequence::Faint => {
+                    self.state.faint = true;
+                }
+
+                EscapeSequence::NormalItensity => {
+                    self.state.faint = false;
+                }
+
                 EscapeSequence::BlackletterFont
-                | EscapeSequence::Faint
                 | EscapeSequence::SlowBlink
                 | EscapeSequence::NotBlinking
                 | EscapeSequence::ReverseVideo
@@ -224,7 +236,6 @@ impl Perform for Printer<'_> {
                 | EscapeSequence::DisableProportionalSpacing
                 | EscapeSequence::NeitherSuperscriptNorSubscript
                 | EscapeSequence::NotReserved
-                | EscapeSequence::NormalItensity
                 | EscapeSequence::RapidBlink => {
                     eprintln!("not implemented for action: {action:?}")
                 }
@@ -293,9 +304,15 @@ impl From<Printer<'_>> for RgbImage {
                 FontState::ItalicBold => &printer.settings.font_italic_bold,
             };
 
+            let color = if entry.faint {
+                printer.settings.pallete.get_faint_color(entry.foreground_color)
+            } else {
+                printer.settings.pallete.get_color(entry.foreground_color)
+            };
+
             draw_text_mut(
                 &mut image,
-                Rgb(printer.settings.pallete.get_color(entry.foreground_color)),
+                Rgb(color),
                 (*x).try_into().unwrap(),
                 (*y).try_into().unwrap(),
                 printer.settings.scale,

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -16,7 +16,7 @@ use vte::{
 use crate::{
     color::ColorType,
     escape::EscapeSequence,
-    pallete::Palette,
+    palette::Palette,
 };
 
 pub(super) struct Settings<'a> {
@@ -26,7 +26,7 @@ pub(super) struct Settings<'a> {
     pub(super) font_italic_bold: Font<'a>,
     pub(super) font_height: f32,
     pub(super) scale: Scale,
-    pub(super) pallete: Palette,
+    pub(super) palette: Palette,
     pub(super) png_width: Option<u32>,
 }
 
@@ -65,7 +65,7 @@ struct State {
     font: FontState,
     last_execute_byte: Option<u8>,
     underline: bool,
-    faint: bool
+    faint: bool,
 }
 
 pub(super) struct Printer<'a> {
@@ -276,7 +276,7 @@ impl From<Printer<'_>> for RgbImage {
             *pixel = image::Rgb(
                 printer
                     .settings
-                    .pallete
+                    .palette
                     .get_color(ColorType::PrimaryBackground),
             );
         }
@@ -289,7 +289,7 @@ impl From<Printer<'_>> for RgbImage {
             for x in *x..background_end_x {
                 for y in *y..background_end_y {
                     let pixel =
-                        image::Rgb(printer.settings.pallete.get_color(entry.background_color));
+                        image::Rgb(printer.settings.palette.get_color(entry.background_color));
 
                     image.put_pixel(x, y, pixel);
                 }
@@ -305,9 +305,12 @@ impl From<Printer<'_>> for RgbImage {
             };
 
             let color = if entry.faint {
-                printer.settings.pallete.get_faint_color(entry.foreground_color)
+                printer
+                    .settings
+                    .palette
+                    .get_faint_color(entry.foreground_color)
             } else {
-                printer.settings.pallete.get_color(entry.foreground_color)
+                printer.settings.palette.get_color(entry.foreground_color)
             };
 
             draw_text_mut(
@@ -327,7 +330,7 @@ impl From<Printer<'_>> for RgbImage {
 
                 for underline_x in underline_start..underline_end {
                     let pixel =
-                        image::Rgb(printer.settings.pallete.get_color(entry.foreground_color));
+                        image::Rgb(printer.settings.palette.get_color(entry.foreground_color));
 
                     image.put_pixel(underline_x, underline_y - 1, pixel);
                     image.put_pixel(underline_x, underline_y, pixel);


### PR DESCRIPTION
Hi @AlexanderThaller, 

Thanks for this wonderful piece of code. This is the only working tool I have found to be able to print ANSI outputs properly around here. I use it to produce rasters for the [`xan`](https://github.com/medialab/xan/) CLI tool ASCII-art like datavisualisations in the terminal.

This said, it lacks support for some ANSI escape codes. This PR is therefore a first step toward better support, by dealing with truecolor rgb colors.

I intend to also add support for the `dimmed` modifier and improve the command line to accept stdin if no input path was provided. Tell me if this is fine with you.

Have a good sunday,

EDIT: I have added a commit fixing bright colors foreground escape code parsing.

EDIT: I have added a commit for `faint` colors (also called `dimmed` sometimes)